### PR TITLE
Change: enable to pass 'misc' field in JSON format in API requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,23 +198,21 @@ curl -X POST http://poloxy.yourdomain.com/v1/item -d '{
 Mail:
 
 ```
-cat <<EOD | curl -X POST http://poloxy.yourdomain.com/v1/item -d @-
-{
+curl -X POST http://poloxy.yourdomain.com/v1/item -d '{
     "name": "Error Rate",
     "group": "web/rails-app",
     "type": "Mail",
     "level": "5",
     "address": "developers@yourdomain.com,admin@yourdomain.com",
     "message": "Error Rate is Over 5%",
-    "misc": "{
-        \"mail\": {
-            \"from\": \"alert@yourdomain.com\",
-            \"cc\": \"support@yourdomain.com\",
-            \"bcc\": \"poloxy-ops@yourdomain.com\"
+    "misc": {
+        "mail": {
+            "from": "alert@yourdomain.com",
+            "cc": "support@yourdomain.com",
+            "bcc": "poloxy-ops@yourdomain.com"
         }
-    }"
-}
-EOD
+    }
+}'
 ```
 
 # Additional Resources of "poloxy"

--- a/bin/poloxy-cli
+++ b/bin/poloxy-cli
@@ -24,5 +24,8 @@ end
 Poloxy::DataStore.new.connect
 
 p param
+if param['misc']
+  param['misc'] = JSON.parse param['misc']
+end
 
 item = Poloxy::Item.new.create param

--- a/lib/poloxy/item.rb
+++ b/lib/poloxy/item.rb
@@ -10,6 +10,9 @@ class Poloxy::Item
     params = args.dup
     params['group'] = str2group_path params['group'] || Poloxy::DEFAULT_GROUP
     params['level'] = Poloxy::MIN_LEVEL if params['level'].to_i < Poloxy::MIN_LEVEL
+    if params['misc']
+      params['misc'] = params['misc'].to_json
+    end
     params['received_at'] = now
     params['expire_at'] = now + @config.message['default_expire']
     item = @data_model.spawn 'Item', params


### PR DESCRIPTION
'Misc' field must be passed as text, but it seems more convinient to receive as JSON for API users.